### PR TITLE
Remove unnecessary rclone ls call

### DIFF
--- a/tests/locations/test_rclone.py
+++ b/tests/locations/test_rclone.py
@@ -156,8 +156,9 @@ def test_rclone_ensure_container_exists(
     else:
         with pytest.raises(models.StorageException):
             rclone_space._ensure_container_exists()
-            subprocess.assert_called_with(["mkdir", "testremote:testcontainer"])
 
+    args, _ = subprocess.Popen.call_args
+    assert args[0] == ["rclone", "mkdir", "testremote:testcontainer"]
 
 @pytest.mark.parametrize(
     "listremotes_return, expected_return, subprocess_return_code, raises_storage_exception",


### PR DESCRIPTION
In the rclone model's _ensure_container_exists method, rclone ls is used to check whether a container exists on an rclone remote. If not, rclone mkdir is used to create it. However, rclone mkdir returns success without making any changes if the directory already exists, so calling rclone ls and then rclone mkdir if the container doesn't exist is equivalent to just calling rclone mkdir. Further, rclone ls can take quite some time to respond if the remote has a large number of items in its root directory. This commit removes the ls call and updates _ensure_container_exists to simply call mkdir in all cases.