### PR TITLE
Remove unnecessary rclone ls call

### DIFF
--- a/src/archivematica/storage_service/locations/models/rclone.py
+++ b/src/archivematica/storage_service/locations/models/rclone.py
@@ -119,26 +119,18 @@ class RClone(models.Model):
         raise StorageException("rclone remote matching %s not found", self.remote_name)
 
     def _ensure_container_exists(self):
-        """Ensure that the S3 bucket or other container exists by asking it
-        something about itself. If we cannot retrieve metadata about it then
-        we attempt to create the bucket, else, we raise a StorageException.
+        """Ensure that the S3 bucket or other container exists by creating it if it doesn't.
+        If the creation attempt fails, we raise a StorageException.
         """
-        LOGGER.debug("Test that container '%s' exists", self.container)
+        LOGGER.debug("Create container '%s' if it doesn't exist", self.container)
         prefixed_container_name = f"{self.remote_prefix}{self.container}"
-        cmd = ["ls", prefixed_container_name]
+        create_container_cmd = ["mkdir", prefixed_container_name]
         try:
-            self._execute_rclone_subcommand(cmd)
+            self._execute_rclone_subcommand(create_container_cmd)
         except StorageException:
-            LOGGER.info("Creating container '%s'", self.container)
-            create_container_cmd = ["mkdir", prefixed_container_name]
-            try:
-                self._execute_rclone_subcommand(create_container_cmd)
-            except StorageException:
-                err_msg = (
-                    f"Unable to find or create container {prefixed_container_name}"
-                )
-                LOGGER.error(err_msg)
-                raise StorageException(err_msg)
+            err_msg = f"Unable to find or create container {prefixed_container_name}"
+            LOGGER.error(err_msg)
+            raise StorageException(err_msg)
 
     def browse(self, path):
         """Browse RClone location."""

--- a/tests/locations/test_rclone.py
+++ b/tests/locations/test_rclone.py
@@ -163,7 +163,9 @@ def test_rclone_ensure_container_exists(
     else:
         with pytest.raises(models.StorageException):
             rclone_space._ensure_container_exists()
-            subprocess.assert_called_with(["mkdir", "testremote:testcontainer"])
+
+    args, _ = subprocess.Popen.call_args
+    assert args[0] == ["rclone", "mkdir", "testremote:testcontainer"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In the rclone model's _ensure_container_exists method, rclone ls is used to check whether a container exists on an rclone remote. If not, rclone mkdir is used to create it. However, rclone mkdir returns success without making any changes if the directory already exists, so calling rclone ls and then rclone mkdir if the container doesn't exist is equivalent to just calling rclone mkdir. Further, rclone ls can take quite some time to respond if the remote has a large number of items in its root directory. This commit removes the ls call and updates _ensure_container_exists to simply call mkdir in all cases.