### PR TITLE
Make target repo of build action configurable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,23 @@ on:
     outputs:
       ARCHIVEMATICA_STORAGE_SERVICE_IMAGE_TAG:
         value: ${{ jobs.generate_image_tags.outputs.ARCHIVEMATICA_STORAGE_SERVICE_IMAGE_TAG}}
+    inputs:
+      target_repo:
+        type: string
+        required: false
+        default: PermanentOrg/archivematica-storage-service
   workflow_dispatch:
+    inputs:
+      target_repo:
+        type: string
+        required: false
+        default: PermanentOrg/archivematica-storage-service
   push:
+    inputs:
+      target_repo:
+        type: string
+        required: false
+        default: PermanentOrg/archivematica-storage-service
     branches:
       - main
 jobs:
@@ -36,6 +51,8 @@ jobs:
       ARCHIVEMATICA_STORAGE_SERVICE_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.ARCHIVEMATICA_STORAGE_SERVICE_IMAGE_TAG}}
     steps:
       - uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.target_repo }}
       - run: docker build -t $ARCHIVEMATICA_STORAGE_SERVICE_IMAGE_TAG --target archivematica-storage-service -f Dockerfile .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com


### PR DESCRIPTION
The build action in this repo is intended to be callable from our infrastructure repo as part of an Archivematica deploy. However, when a workflow is called from a separate repo, it runs in the context of that repo, so by default actions/checkout checks out the repo calling the workflow. In this case we want it to actually check out this repo. To achieve that, we make target_repo and input of the build workflow, defaulting to this repo, and use target_repo to explicitly specify what actions/checkout checks out.